### PR TITLE
Make ^= exponent assignment

### DIFF
--- a/patch/compound-assign.patch
+++ b/patch/compound-assign.patch
@@ -121,7 +121,7 @@ index 284ef1f0..e85c83fe 100644
 +    case TK_SHREQ: return OPR_SHR;
 +    case TK_BANDEQ: return OPR_BAND;
 +    case TK_BOREQ: return OPR_BOR;
-+    case TK_BXOREQ: return OPR_BXOR;
++    case TK_BXOREQ: return OPR_POW;
      default: return OPR_NOBINOPR;
    }
  }

--- a/tests/operator_additions.lua
+++ b/tests/operator_additions.lua
@@ -39,7 +39,8 @@ assert_equal(c, 2, "bit and equals")
 c |= 9
 assert_equal(c, 11, "bit or equals")
 
-c ^= 10
-assert_equal(c, 1, "bit xor equals")
+c = 2
+c ^= 3
+assert_equal(c, 8, "exponent equals")
 
 print("operator additions tests passed")


### PR DESCRIPTION
Fixes #1 

- map ^= compound assignment to exponent (pow) operator
- update operator additions test to expect exponent behavior